### PR TITLE
Method does not work correctly for numerical variable, "dum" binning

### DIFF
--- a/R/woe.binning.deploy.R
+++ b/R/woe.binning.deploy.R
@@ -27,9 +27,9 @@ woe.binning.deploy.2 <- function(df, pred.var, look.up.table, add.woe.or.dum.var
 			binned.var <- dfrm.binned[,1]
 			for ( level in unique(binned.var) ){
 				# Remove special characters from binned intervals
-				level <- gsub("(","",level, fixed = TRUE)
-				level <- gsub("]","",level, fixed = TRUE)
-				level <- gsub(",",".",level, fixed = TRUE)
+				#level <- gsub("(","",level, fixed = TRUE)
+				#level <- gsub("]","",level, fixed = TRUE)
+				#level <- gsub(",",".",level, fixed = TRUE)
 				dfrm.binned[paste("dum",pred.var,gsub(" ","",level),"binned",sep=".")] <- ifelse(binned.var==level,1,0)
 			}
 		}


### PR DESCRIPTION
All dummy variables that are created from numerical variable are always 0.

It happens because of changes that variable "level" undergo  in 30-32 lines of code.
After that change we compare "binned.var" without 30-32 changes with changed "level" variable in line 33 and they are never equal.

This problem is even reproduced in help example for function woe.binning.deploy:
df.with.binned.vars.added <- woe.binning.deploy(df, binning,
                                               min.iv.total=0.1,
                                               add.woe.or.dum.var='dum')